### PR TITLE
fix: serve.admin.request_log.disable_for_health behaviour

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -160,8 +160,9 @@ func ServeAdmin(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args 
 		l,
 		"admin#"+c.SelfPublicURL().String(),
 	)
+
 	if r.Config(ctx).DisableAdminHealthRequestLog() {
-		adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+		adminLogger.ExcludePaths(x.AdminPrefix+healthx.AliveCheckPath, x.AdminPrefix+healthx.ReadyCheckPath)
 	}
 	n.Use(adminLogger)
 	n.UseFunc(x.RedirectAdminMiddleware)


### PR DESCRIPTION
Since admin endpoints have been moved under `/admin`, `serve.admin.request_log.disable_for_health` parameter doesn't work anymore.
This PR fixes the issue by adding the missing prefix in front of ignored URLs

## Related issue(s)

## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

